### PR TITLE
test: add Xquik OpenAPI 3.1 fixture validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prepack": "npm run build",
     "start": "node build/index.js",
     "dev": "tsc --watch",
+    "test:openapi31": "node test-openapi31-fixture.js",
     "test:smoke": "npm run build && node test-smoke.js",
     "test:mcp": "npm run build && npx @modelcontextprotocol/inspector-cli --config tests/mcp-inspector.config.json --server specmatic --cli",
     "inspect": "npm run build && npx @modelcontextprotocol/inspector-cli --config tests/mcp-inspector.config.json --server specmatic",

--- a/test-openapi31-fixture.js
+++ b/test-openapi31-fixture.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fixturePath = path.join(__dirname, 'test-xquik-openapi31.yaml');
+const fixture = fs.readFileSync(fixturePath, 'utf8');
+
+const checks = [
+  ['OpenAPI 3.1 version', /^openapi:\s*3\.1\.0/m],
+  ['Xquik API title', /title:\s*Xquik API/m],
+  ['search endpoint', /\/api\/v1\/x\/tweets\/search:/m],
+  ['API key security scheme', /name:\s*x-api-key/m],
+  ['search operation id', /operationId:\s*searchTweets/m],
+];
+
+const failures = checks
+  .filter(([, pattern]) => !pattern.test(fixture))
+  .map(([label]) => label);
+
+if (failures.length > 0) {
+  console.error(`Invalid OpenAPI 3.1 fixture: ${failures.join(', ')}`);
+  process.exitCode = 1;
+} else {
+  console.log('OpenAPI 3.1 fixture validated');
+}

--- a/test-xquik-openapi31.yaml
+++ b/test-xquik-openapi31.yaml
@@ -1,0 +1,67 @@
+openapi: 3.1.0
+info:
+  title: Xquik API
+  version: 1.0.0
+servers:
+  - url: https://xquik.com
+security:
+  - xApiKey: []
+paths:
+  /api/v1/x/tweets/search:
+    get:
+      summary: Search X posts
+      operationId: searchTweets
+      tags:
+        - x
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Search query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of posts to return
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchTweetsResponse"
+components:
+  securitySchemes:
+    xApiKey:
+      type: apiKey
+      in: header
+      name: x-api-key
+  schemas:
+    Tweet:
+      type: object
+      required:
+        - id
+        - text
+      properties:
+        id:
+          type: string
+        text:
+          type: string
+        authorUsername:
+          type: string
+    SearchTweetsResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Tweet"
+        nextCursor:
+          type: string


### PR DESCRIPTION
## Summary

- Add a compact Xquik OpenAPI 3.1 fixture with API key security metadata.
- Add a small local fixture validation script and package script for fast checks.

## Validation

- `npm run test:openapi31`
- `npm run build`
